### PR TITLE
Don't match underscores at start of key

### DIFF
--- a/lib/json_key_transformer_middleware/middleware.rb
+++ b/lib/json_key_transformer_middleware/middleware.rb
@@ -25,7 +25,7 @@ module JsonKeyTransformerMiddleware
 
     # 'key_name' -> 'keyName'
     def underscore_to_camel(key)
-      key.gsub(/_([a-z0-9])/) { $1.upcase }
+      key.gsub(/(?!^)_([a-z0-9])/) { $1.upcase }
     end
   end
 


### PR DESCRIPTION
We use this in a fork and figured it may be liked here. If not, feel free to close this PR and we'll just maintain our own fork.

We had the need in our API to return keys prepended with `_` (e.g. `_error` for Redux Form). This was causing problems, as the key was being transformed into `Error` going out.

This PR changes the `underscore_to_camel()` behavior to ignore keys that start with an underscore. This means that `_error` remains `_error`, but `_error_messages` would still be `_errorMessages`, etc.