### PR TITLE
Support skipping certain path(s) with config `skip_paths`

### DIFF
--- a/lib/json_key_transformer_middleware/incoming_json_formatter.rb
+++ b/lib/json_key_transformer_middleware/incoming_json_formatter.rb
@@ -6,13 +6,15 @@ module JsonKeyTransformerMiddleware
   class IncomingJsonFormatter < Middleware
 
     def call(env)
-      object = Oj.load(env['rack.input'].read)
-      transformed_object = HashKeyTransformer.send(middleware_config.incoming_strategy, object, middleware_config.incoming_strategy_options)
-      result = Oj.dump(transformed_object, mode: :compat)
+      unless should_skip?(env)
+        object = Oj.load(env['rack.input'].read)
+        transformed_object = HashKeyTransformer.send(middleware_config.incoming_strategy, object, middleware_config.incoming_strategy_options)
+        result = Oj.dump(transformed_object, mode: :compat)
 
-      env['rack.input'] = StringIO.new(result)
-      # Rails uses this elsewhere to parse 'rack.input', it must be updated to avoid truncation
-      env['CONTENT_LENGTH'] = result.length.to_s
+        env['rack.input'] = StringIO.new(result)
+        # Rails uses this elsewhere to parse 'rack.input', it must be updated to avoid truncation
+        env['CONTENT_LENGTH'] = result.length.to_s
+      end
 
       @app.call(env)
     end

--- a/lib/json_key_transformer_middleware/incoming_params_formatter.rb
+++ b/lib/json_key_transformer_middleware/incoming_params_formatter.rb
@@ -6,9 +6,11 @@ module JsonKeyTransformerMiddleware
   class IncomingParamsFormatter < Middleware
 
     def call(env)
-      parsed_params = Rack::Utils.parse_nested_query(env['QUERY_STRING'])
-      transformed_params = HashKeyTransformer.send(middleware_config.incoming_strategy, parsed_params, middleware_config.incoming_strategy_options)
-      env['QUERY_STRING'] = Rack::Utils.build_nested_query(transformed_params)
+      unless should_skip?(env)
+        parsed_params = Rack::Utils.parse_nested_query(env['QUERY_STRING'])
+        transformed_params = HashKeyTransformer.send(middleware_config.incoming_strategy, parsed_params, middleware_config.incoming_strategy_options)
+        env['QUERY_STRING'] = Rack::Utils.build_nested_query(transformed_params)
+      end
 
       @app.call(env)
     end

--- a/lib/json_key_transformer_middleware/middleware.rb
+++ b/lib/json_key_transformer_middleware/middleware.rb
@@ -6,9 +6,23 @@ module JsonKeyTransformerMiddleware
       @middleware_config = middleware_config
     end
 
+    protected
+
+    def should_skip?(env)
+      middleware_config.skip_paths.any? do |skip_path|
+        case skip_path
+        when String
+          skip_path == env['PATH_INFO']
+        when Regexp
+          skip_path.match? env['PATH_INFO']
+        end
+      end
+    end
+
     private
 
     attr_reader :app, :middleware_config
+
   end
 
 end

--- a/lib/json_key_transformer_middleware/outgoing_json_formatter.rb
+++ b/lib/json_key_transformer_middleware/outgoing_json_formatter.rb
@@ -8,6 +8,8 @@ module JsonKeyTransformerMiddleware
     def call(env)
       status, headers, body = @app.call(env)
 
+      return [status, headers, body] if should_skip?(env)
+
       new_body = build_new_body(body)
 
       [status, headers, new_body]

--- a/lib/json_key_transformer_middleware/railtie.rb
+++ b/lib/json_key_transformer_middleware/railtie.rb
@@ -9,6 +9,7 @@ module JsonKeyTransformerMiddleware
     config.json_key_transformer_middleware.incoming_strategy_options = ActiveSupport::OrderedOptions.new
     config.json_key_transformer_middleware.outgoing_strategy = :transform_underscore_to_camel
     config.json_key_transformer_middleware.outgoing_strategy_options = ActiveSupport::OrderedOptions.new
+    config.json_key_transformer_middleware.skip_paths = []
 
     config.app_middleware.insert_after(Rails::Rack::Logger, JsonKeyTransformerMiddleware::IncomingParamsFormatter, config.json_key_transformer_middleware)
     config.app_middleware.insert_after(Rails::Rack::Logger, JsonKeyTransformerMiddleware::IncomingJsonFormatter, config.json_key_transformer_middleware)

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,7 @@ The Railtie provides these configuration options:
 * `incoming_strategy_options` - no options set by default.
 * `outgoing_strategy` - default value of `:transform_underscore_to_camel`.
 * `outgoing_strategy_options` - no options set by default.
+* `skip_paths` - skip the transformation if HTTP request path matches. e.g. `[/^\/admin/, '/graphql']`
 
 Here is an example Rails initializer which turns on the `outgoing_strategy_options.keep_lead_underscore` option:
 


### PR DESCRIPTION
Thanks for creating this gem!

This PR support skipping certain paths with a new configuration option `skip_paths`.

`skip_paths` supports both String and Regexp, and will be matched against `env['PATH_INFO']`.

Example usage:
```rb
Rails.application.config.json_key_transformer_middleware.skip_paths = [/^\/admin/, '/graphql']

# Will not transform neither `GET /admin/foo?bar_id=1` nor `POST /graphql`
```

Some thoughts:
1. ~Perhaps `skip_paths` is a better name?~ I updated `excluded_paths` to `skip_paths`
2. I also considered accepting a proc to achieve the same goal (e.g. `should_skip = ->(env) { env['PATH_INFO'].match?('/foobar') }`) but thinking this could be a bit confusing, and users may not need such flexibility. If [providing another advanced config `should_skip`](https://github.com/choznerol/json_key_transformer_middleware/commit/333d85b1a58df902ffd724c1decdfd787558327f#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R71) sounds good I can send another PR for that.
